### PR TITLE
Proposed fix for frequent Witness crashes (Issue #64)

### DIFF
--- a/witness/events.zil
+++ b/witness/events.zil
@@ -596,6 +596,9 @@ Each character has a tendency to move from one place to another
 at certain times. They all converge on the living room at about
 noon."
 
+<CONSTANT I-LINDER 0>
+<CONSTANT I-CAT 0>
+
 "Goal tables for the 6 characters (including PLAYER), offset
 by the preceding constants, which, for a given character,
 is the P?CHARACTER property of the object."
@@ -603,10 +606,10 @@ is the P?CHARACTER property of the object."
 <GLOBAL GOAL-TABLES
 	<TABLE <TABLE <> <> <> <> 1 <> <> I-FOLLOW 4 4>
 	       <TABLE <> <> <> <> 1 <> <> I-PHONG 3 3>
-	       ;<TABLE <> <> <> <> 1 <> <> I-LINDER 4 4>
+	       <TABLE <> <> <> <> 1 <> <> I-LINDER 4 4>
 	       <TABLE <> <> <> <> 1 <> <> I-STILES 9 9>
 	       <TABLE <> <> <> <> 1 <> <> I-MONICA 2 2>
-	       ;<TABLE <> <> <> <> 1 <> <> I-CAT 1 1>>>
+	       <TABLE <> <> <> <> 1 <> <> I-CAT 1 1>>>
 
 <GLOBAL ATTENTION-TABLE <TABLE 0 0 0 0 0 0 0 0>>
 


### PR DESCRIPTION
This restores two missing entries from GOAL-TABLES that were apparently disabled to fix compilation, but never re-enabled. This presumably caused the game to use invalid data when moving actors to their goals.

The missing I-LINDER and I-CAT are 0 in the original witnessdat.zap file - perhaps the original compiler did that with all missing identifiers? - so I've defined them as constants here. This should preserve both the original behavior, and the readability of the table.