### PR TITLE
Proposed fix for minor spacing issue in AMFV (Issue #75)

### DIFF
--- a/amfv/prism.zil
+++ b/amfv/prism.zil
@@ -1387,7 +1387,7 @@ six hours have passed." CR>)>
 		<COND (<EQUAL? ,PART-FLAG 4>
 		       <TELL "There are currently no active outlets." CR>)
 		      (T
-		       <TELL "    ">
+		       <TELL "   ">
 		       <PRINTD ,CONTROL-CENTER>
 		       <TELL " (PPCC)|    ">
 		       <PRINTD ,ROOFTOP>


### PR DESCRIPTION
This reverts OUTLET-F to its earlier form, which when compiled with ZILF will mimic Release 77, and all surviving earlier test versions. (It was broken in Release 79, presumably by a compiler change.)

It almost seems silly making a pull request out of this. Almost.