### PR TITLE
Fix for missing room description after intro (Issue #66)

### DIFF
--- a/seastalker/main.zil
+++ b/seastalker/main.zil
@@ -55,6 +55,7 @@ Copyright (C) 1984, 1985 Infocom, Inc.  All rights reserved."
 	<SETG HERE ,CENTER-OF-LAB>
 	<MOVE ,TIP ,HERE>
 	<MOVE ,PLAYER ,HERE>
+	<V-LOOK>
 	<MAIN-LOOP>
 	<AGAIN>>    
 


### PR DESCRIPTION
This simply adds a missing call to ```<V-LOOK>```. Several other games do that, so it should work here too.