### PR TITLE
Fixed status line for Suspect, Wishbringer and The Witness (Issue #70)

### DIFF
--- a/suspect/m3.zil
+++ b/suspect/m3.zil
@@ -1,6 +1,8 @@
 "COMPILE/LOAD FILE for M3
 Copyright (C) 1984 Infocom, Inc.  All rights reserved."
 
+<VERSION ZIP TIME>
+
 <SETG DEBUGGING? <>>
 
 ;<REPEAT (CHR)

--- a/wishbringer/j2.zil
+++ b/wishbringer/j2.zil
@@ -1,5 +1,7 @@
 "J2 for WISHBRINGER: (C)1985 Infocom, Inc. All Rights Reserved."
 
+<VERSION ZIP TIME>
+
 <PRINC "
 WISHBRINGER: The Magick Stone of Dreams
 

--- a/witness/witness.zil
+++ b/witness/witness.zil
@@ -1,6 +1,8 @@
 "COMPILE/LOAD FILE for WITNESS
 Copyright (C) 1983 Infocom, Inc.  All rights reserved."
 
+<VERSION ZIP TIME>
+
 <COND (<GASSIGNED? PREDGEN>
        <SETG ZSTR-ON <SETG ZSTR-OFF ,TIME>>
        <PRINC "Compiling">


### PR DESCRIPTION
Trivial fix to make Suspect, Wishbringer and The Witness show Time on the status line, instead of Score and Moves.
