### PR TITLE
Zork II - Fix for menhir being incorrectly described

### DIFF
--- a/zork2/2actions.zil
+++ b/zork2/2actions.zil
@@ -2857,9 +2857,7 @@ rough-hewn and unworked, others smooth and well-finished. One side of
 the room appears to have been used to quarry building blocks, the other
 to produce menhirs (standing stones). Obvious passages lead north and
 south." CR>
-		<COND (<IN? ,MENHIR ,LOCAL-GLOBALS>
-		       <DESCRIBE-MENHIR>)>
-		T)>>
+		<DESCRIBE-MENHIR>)>>
 
 <ROUTINE DESCRIBE-MENHIR ()
 	 <COND (<EQUAL? ,HERE ,MENHIR-ROOM>

--- a/zork2/2actions.zil
+++ b/zork2/2actions.zil
@@ -2872,8 +2872,6 @@ southwest. On this side of the menhir is carved an ornate letter \"F\"." CR>)
 		      (<EQUAL? ,MENHIR-POSITION 2>
 		       <TELL
 "A dark opening leads southwest." CR>)
-		      (<EQUAL? ,MENHIR-POSITION 3>
-		       <TELL "There is a huge menhir here." CR>)
 		      (T
 		       <TELL
 "There is a huge menhir floating like a feather in midair here. A
@@ -3237,7 +3235,7 @@ The wizard runs from the room in terror." CR>
 			     <MOVE ,MENHIR ,PENTAGRAM-ROOM>
 			     <FCLEAR ,MENHIR ,NDESCBIT>
 			     <FCLEAR ,MENHIR ,TAKEBIT>
-			     <SETG MENHIR-POSITION 3>
+			     <SETG MENHIR-POSITION 2>
 			     <TELL
 "He waves his hands, and the menhir drops softly at your feet." CR>
 			     <GENIE-LEAVES>)

--- a/zork2/2dungeon.zil
+++ b/zork2/2dungeon.zil
@@ -668,6 +668,7 @@ On the wall is crudely chiseled the number \"8\".")
 	(ADJECTIVE HUGE HEAVY ENORMOUS)
 	(FLAGS NDESCBIT READBIT TURNBIT)
 	(DESC "enormous menhir")
+	(LDESC "There is a huge menhir here.")
 	(ACTION MENHIR-FCN)>
 
 <ROOM KENNEL


### PR DESCRIPTION
This fixes a couple of errors in how the menhir is described:

- When asking the demon to give you the menhir, it is moved to the Pentagram Room. There it was incorrectly described as "a enormous menhir".
- The Menhir Room only mentioned the passage to the southwest in brief mode if the menhir was gone from the room. (Or, from a technical point, when it was gone from LOCAL-GLOBALS.)
- The description of the menhir floating in the air was never printed.

This pull request does not, however, address the problem where you can examine the menhir in the Menhir Room (and the Kennel), even though it's no longer in the room. The pull request for making Mini-Zork II playable has a possible fix for that, and a couple of other bugs that may also be in the full game.

I don't know why DESCRIBE-MENHIR tests if HERE is the MENHIR-ROOM. I removed the test in Mini-Zork II, where space is a consideration, but left it here.

This is the debug verb I added to quickly get me to where I could test the various states of the menhir:

```
<SYNTAX DEBUG = V-DEBUG>
<ROUTINE V-DEBUG ()
	 <SETG CAROUSEL-FLIP-FLAG T>	; "Stop the spinning"
	 <SETG GUARDIAN-FED T>	  	; "Open the door"
	 <SETG WIZ-DOOR-FLAG T>
	 <FSET ,WIZ-DOOR ,OPENBIT>
	 <MOVE ,GENIE ,PENTAGRAM-ROOM>	; "Summon and satisfy the demon"
	 <FCLEAR ,GENIE ,INVISIBLE>
	 <SETG GENIE-READY? T>
	 <DISABLE <INT I-WIZARD>>	; "Summon the Wizard"
	 <MOVE ,WIZARD ,PENTAGRAM-ROOM>
	 <SETG ALWAYS-LIT T>		; "Let there be light"
	 <SETG LIT T>
	 <MOVE ,BRICK ,ADVENTURER>	; "It's the bomb!"
	 <MOVE ,FUSE ,ADVENTURER>
	 <MOVE ,MATCH ,ADVENTURER>
	 <GOTO ,PENTAGRAM-ROOM>>
```

The states I'm aware of are:

- The menhir is in the room, blocking the southwest exit.
- The menhir is in the room, blocking the southwest exit, undamaged by the explosion.
- The menhir has been moved aside by the demon.
- The menhir has been moved to the Pentagram Room by the demon.
- The menhir is being levitated by the wand.

Some of these states are described in both the brief and the verbose version of the Menhir Room's description.