### PR TITLE
Fixed conditions for Monica's acquittal if you arrest her and Phong.

### DIFF
--- a/witness/events.zil
+++ b/witness/events.zil
@@ -1764,17 +1764,16 @@ mechanism.|" CR>
 		      <TELL
 "While Monica could have conspired with him and aided him, she too was
 acquitted of conspiracy, because ">
-		      <COND (<NOT <FSET? ,GUN-RECEIPT ,TOUCHBIT>>
+		      <COND (<NOT ,MONICA-HAS-MOTIVE>
+			     <TELL "she had no apparent motive.|" CR>)
+			    (<OR ,SEEN-MONICA-AT-CLOCK ,USED-CLOCK-KEY>
 			     <TELL
 "he was. If only we had tried her for plain murder instead of conspiracy!|"
 CR>)
-			    (,MONICA-HAS-MOTIVE
+			    (T
 			     <TELL "the available
 evidence against her was circumstantial, since there was no definite
-link between her and the hidden gun mechanism.|" CR>)
-			    (<OR ,SEEN-MONICA-AT-CLOCK ,USED-CLOCK-KEY>
-			     <TELL "she had no
-apparent motive.|" CR>)>)>)
+link between her and the hidden gun mechanism.|" CR>)>)>)
 	      (<==? .PERSON ,MONICA>
 	       <COND (,MONICA-HAS-MOTIVE
 		      <COND (<OR ,SEEN-MONICA-AT-CLOCK ,USED-CLOCK-KEY>


### PR DESCRIPTION
Under certain conditions, if you arrest both Phong and Monica together she will be acquitted "because", with no reason given:

```
Duffy seems to read your thoughts, as he appears with Monica and Mr. Phong in
handcuffs. "Let's not have any trouble, now," says Duffy, in his unique way.
They head for the driveway, where a police car waits with engine purring.

Text of a letter from Police Chief Klutz dated February 28:

Dear Detective:

    The elaborate set-up in Mr. Linder's office was ingenious. You deserve
congratulations for your work in detecting it.

I am sorry to report that the trial jury acquitted Mr. Phong of the murder of
his employer. Apparently they believed that he lacks the mechanical skills
necessary to construct the hidden gun mechanism.

While Monica could have conspired with him and aided him, she too was acquitted
of conspiracy, because

The case has come to an end. Would you like to start your investigation over
from scratch? (Answer YES or NO.) >
```

To understand why, you need to know a bit more about how the game interprets your knowledge of the case. First of all, you need to know about the hidden gun. The simplest way (even if it makes no sense) is to:

- Enter the house and wait for the murder to happen.
- Push the button.
- When Phong arrives, ask him about the button.

Now you can arrest Phong and Monica for the murder without being told they weren't at the scene at the time. Phong will be acquitted for not having the technical skill to set up the hidden gun and, optionally, for not having any link to the weapon. The reason for Monica's acquittal is:

- If you haven't touched the gun receipt, she is acquitted "because he was", with the police chief lamenting that you should have tried her for murder, not conspiracy. (Even if you don't have a motive, and you don't know she has the clock key.)
- Otherwise, if you have a motive for her she is acquitted because the evidence is circumstantial and "there was no definite link between her and the hidden gun mechanism". (Even if you know she has the clock key.)
- Otherwise, if you know she has the clock key she is acquitted "because she had no motive". 
- Otherwise, she is acquitted "because".

So to get the bad ending:

- Enter the house and wait for the murder to happen.
- Push the button.
- When Phong arrives, ask him about the button.
- Go to Phong's room and get the gun receipt from the mystery book.
- When Monica returns, arrest Phong and Monica.

I've changed this to match the logic for when you arrest only her more closely:

- If you have no motive for her, she's always acquitted because of that. It doesn't matter what else you have on her.
- Otherwise, if you know she has the clock key she is still acquitted "because he was". You had both motive and a connection to the hidden gun, so it makes sense for the police chief to say you should have tried her for murder, not conspiracy.
- Otherwise, since you only had her motive, she's acquitted because the evidence was just circumstantial, with no link between her and the hidden gun.

So the gun receipt is not tested. But it isn't if you arrest her on her own either, and since Phong's acquittal message depends on the gun receipt I think it's covered well enough by "because he was".

Finally, just for fun, here is the shortest solution to the game that I've been able to come up with:

```
N. N. RING BELL. ASK PHONG ABOUT SUICIDE. WAIT. SIT ON WOODEN CHAIR.
WAIT UNTIL 9:04. [answer YES until Mr Linder is dead] GET UP. PUSH
BUTTON. WAIT FOR PHONG. ASK PHONG ABOUT BUTTON. WAIT. [answer YES
until Phong leaves] HIDE BEHIND LOUNGE. WAIT UNTIL 1:00. [answer YES
until Duffy returns] ARREST MONICA.
```
